### PR TITLE
[BOARD] 게시판 탭 목록 조회, 게시글 상세보기 기능 구현

### DIFF
--- a/myhands/src/main/java/tabom/myhands/domain/board/controller/BoardController.java
+++ b/myhands/src/main/java/tabom/myhands/domain/board/controller/BoardController.java
@@ -1,0 +1,35 @@
+package tabom.myhands.domain.board.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import tabom.myhands.common.properties.ResponseProperties;
+import tabom.myhands.common.response.DtoResponse;
+import tabom.myhands.domain.board.dto.BoardResponse;
+import tabom.myhands.domain.board.service.BoardService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/board")
+public class BoardController {
+
+    private final BoardService boardService;
+    private final ResponseProperties responseProperties;
+
+    @GetMapping("/overview")
+    public ResponseEntity<DtoResponse<BoardResponse.PostList>> overview (@RequestParam(defaultValue = "6") int size){
+        BoardResponse.PostList response = boardService.overview(size);
+        return ResponseEntity.status(HttpStatus.OK).body(DtoResponse.of(HttpStatus.OK, responseProperties.getSuccess(),response));
+    }
+
+    @GetMapping("/detail")
+    public ResponseEntity<DtoResponse<BoardResponse.PostDetail>> detail(@RequestParam Long id){
+        BoardResponse.PostDetail response = boardService.detail(id);
+        return ResponseEntity.status(HttpStatus.OK).body(DtoResponse.of(HttpStatus.OK, responseProperties.getSuccess(),response));
+    }
+
+}

--- a/myhands/src/main/java/tabom/myhands/domain/board/dto/BoardResponse.java
+++ b/myhands/src/main/java/tabom/myhands/domain/board/dto/BoardResponse.java
@@ -1,0 +1,63 @@
+package tabom.myhands.domain.board.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.*;
+import tabom.myhands.domain.board.entity.Board;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class BoardResponse {
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class PostItem {
+        private Long boardId;
+        private String title;
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss" ,timezone = "Asia/Seoul")
+        private LocalDateTime createdAt;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class PostList {
+        private List<PostItem> overviewList;
+
+        public static PostList build(List<Board> boards) {
+            List<PostItem> postItems = boards.stream()
+                    .map(board -> PostItem.builder()
+                            .boardId(board.getBoardId())
+                            .title(board.getTitle())
+                            .createdAt(board.getCreatedAt())
+                            .build())
+                    .toList();
+            return PostList.builder()
+                    .overviewList(postItems)
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class PostDetail{
+        private Long boardId;
+        private String title;
+        private String content;
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss" ,timezone = "Asia/Seoul")
+        private LocalDateTime createdAt;
+
+        public static PostDetail build(Board board){
+            return PostDetail.builder()
+                    .boardId(board.getBoardId())
+                    .title(board.getTitle())
+                    .content(board.getContent())
+                    .createdAt(board.getCreatedAt())
+                    .build();
+        }
+    }
+}

--- a/myhands/src/main/java/tabom/myhands/domain/board/entity/Board.java
+++ b/myhands/src/main/java/tabom/myhands/domain/board/entity/Board.java
@@ -1,0 +1,41 @@
+package tabom.myhands.domain.board.entity;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "board")
+public class Board {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "board_id")
+    private Long boardId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "title", length = 200, nullable = false)
+    private String title;
+
+    @Column(name = "content", length = 1000, nullable = false)
+    private String content;
+
+    @Column(name = "created_at", nullable = false)
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime createdAt;
+
+    @Column(name = "category", nullable = false)
+    private Integer category;
+
+}

--- a/myhands/src/main/java/tabom/myhands/domain/board/repository/BoardRepository.java
+++ b/myhands/src/main/java/tabom/myhands/domain/board/repository/BoardRepository.java
@@ -1,0 +1,17 @@
+package tabom.myhands.domain.board.repository;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import tabom.myhands.domain.board.entity.Board;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface BoardRepository extends JpaRepository<Board, Long> {
+
+    @Query("SELECT b FROM Board b ORDER BY b.createdAt DESC")
+    List<Board> findTopBySize(Pageable pageable);
+
+    Optional<Board> findByBoardId(Long boardId);
+}

--- a/myhands/src/main/java/tabom/myhands/domain/board/service/BoardService.java
+++ b/myhands/src/main/java/tabom/myhands/domain/board/service/BoardService.java
@@ -1,0 +1,8 @@
+package tabom.myhands.domain.board.service;
+
+import tabom.myhands.domain.board.dto.BoardResponse;
+
+public interface BoardService {
+    BoardResponse.PostList overview(Integer size);
+    BoardResponse.PostDetail detail(Long id);
+}

--- a/myhands/src/main/java/tabom/myhands/domain/board/service/BoardServiceImpl.java
+++ b/myhands/src/main/java/tabom/myhands/domain/board/service/BoardServiceImpl.java
@@ -1,0 +1,36 @@
+package tabom.myhands.domain.board.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import tabom.myhands.domain.board.dto.BoardResponse;
+import tabom.myhands.domain.board.entity.Board;
+import tabom.myhands.domain.board.repository.BoardRepository;
+import tabom.myhands.error.errorcode.BoardErrorCode;
+import tabom.myhands.error.exception.BoardApiException;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BoardServiceImpl implements BoardService{
+
+    private final BoardRepository boardRepository;
+
+    @Override
+    public BoardResponse.PostList overview(Integer size) {
+        if(size <= 0){
+            throw new BoardApiException(BoardErrorCode.INVALID_SIZE_PARAMETER);
+        }
+        List<Board> boards = boardRepository.findTopBySize(PageRequest.of(0, size));
+        return BoardResponse.PostList.build(boards);
+    }
+
+    @Override
+    public BoardResponse.PostDetail detail(Long id) {
+        Board board = boardRepository.findByBoardId(id)
+                .orElseThrow(() -> new BoardApiException(BoardErrorCode.BOARD_ID_NOT_FOUND));
+
+        return BoardResponse.PostDetail.build(board);
+    }
+}

--- a/myhands/src/main/java/tabom/myhands/error/BaseControllerAdvice.java
+++ b/myhands/src/main/java/tabom/myhands/error/BaseControllerAdvice.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import tabom.myhands.common.response.MessageResponse;
 import tabom.myhands.error.exception.AuthApiException;
+import tabom.myhands.error.exception.BoardApiException;
 import tabom.myhands.error.exception.ScheduleApiException;
 import tabom.myhands.error.exception.UserApiException;
 import tabom.myhands.common.response.ErrorResponse;
@@ -87,6 +88,17 @@ public class BaseControllerAdvice {
     @ExceptionHandler(AuthApiException.class)
     public ResponseEntity<ErrorResponse> handleAuthApiException(AuthApiException e, HttpServletRequest req) {
         log.debug("AuthApiException");
+        log.error(req.getRequestURI());
+        log.error(e.getClass().getCanonicalName());
+        log.error(e.getErrorCode().getMessage());
+
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+                .body(ErrorResponse.of(e.getErrorCode()));
+    }
+
+    @ExceptionHandler(BoardApiException.class)
+    public ResponseEntity<ErrorResponse> handleBoardApiException(BoardApiException e, HttpServletRequest req) {
+        log.debug("BoardApiException");
         log.error(req.getRequestURI());
         log.error(e.getClass().getCanonicalName());
         log.error(e.getErrorCode().getMessage());

--- a/myhands/src/main/java/tabom/myhands/error/errorcode/BoardErrorCode.java
+++ b/myhands/src/main/java/tabom/myhands/error/errorcode/BoardErrorCode.java
@@ -1,0 +1,17 @@
+package tabom.myhands.error.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum BoardErrorCode implements ErrorCode{
+
+    INVALID_SIZE_PARAMETER(5000, HttpStatus.BAD_REQUEST, "The size parameter must be greater than 0"),
+    BOARD_ID_NOT_FOUND(5001, HttpStatus.NOT_FOUND, "Board not found with the given ID");
+
+    private final int code;
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/myhands/src/main/java/tabom/myhands/error/exception/BoardApiException.java
+++ b/myhands/src/main/java/tabom/myhands/error/exception/BoardApiException.java
@@ -1,0 +1,15 @@
+package tabom.myhands.error.exception;
+
+import lombok.Getter;
+import tabom.myhands.error.errorcode.ErrorCode;
+
+@Getter
+public class BoardApiException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public BoardApiException(ErrorCode errorCode) {
+      super(errorCode.getMessage());
+      this.errorCode = errorCode;
+    }
+}
+


### PR DESCRIPTION
## PR Description :page_facing_up:
 
### 관련 이슈 번호

- #28 
  
### 주요 변경사항

- [x] 게시판 관련 엔티티, 레포지터리, 컨트롤러, 서비스 구현
- [x] 게시판 탭 클릭시 최신 게시글 목록 조회 API 구현
- [x] 게시글 상세보기 API 구현